### PR TITLE
Update order of includes

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,8 @@ module.exports = {
 		"declaration-colon-space-before": "never",
 
 		"order/order": [
+			"custom-properties",
+            "dollar-variables",
 			{
 				"type": "at-rule",
 				"name": "extend"
@@ -55,14 +57,14 @@ module.exports = {
 			{
 				"type": "at-rule",
 				"name": "include",
-				"parameter": /^(?!respond-to\(.*\)$)/
+				"parameter": "^((?!respond-to|hocus).)*$"
 			},
+			"declarations",
+			"rules",
 			{
 				"type": "at-rule",
 				"name": "media"
-			},
-			"declarations",
-			"rules"
+			}
 		],
 		"order/properties-order": [
 			[{


### PR DESCRIPTION
Let `@media` queries be at the end of the whole thing, and also allow `@include hocus { ... }` to be at the end.

Before:
```
.selector {
    @include hocus { color: green; }
    @media all { ... }
    color: red;
}
```

After:
```
.selector {
    color: red;
    @include hocus { color: green; }
    @media all { ... }
}
```